### PR TITLE
Extension method for registering controllers in AutoFac

### DIFF
--- a/src/WebApiContrib.IoC.AutoFac/RegistrationExtensions.cs
+++ b/src/WebApiContrib.IoC.AutoFac/RegistrationExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Web.Http.Controllers;
+using Autofac;
+using Autofac.Builder;
+using Autofac.Features.Scanning;
+
+namespace WebApiContrib.IoC.AutoFac
+{
+    public static class RegistrationExtensions
+    {
+        public static IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
+            RegisterApiControllers(this ContainerBuilder builder, params Assembly[] controllerAssemblies)
+        {
+            return from t in builder.RegisterAssemblyTypes(controllerAssemblies)
+                   where typeof(IHttpController).IsAssignableFrom(t) && t.Name.EndsWith("Controller")
+                   select t;
+        }
+    }
+}

--- a/src/WebApiContrib.IoC.AutoFac/WebApiContrib.IoC.AutoFac.csproj
+++ b/src/WebApiContrib.IoC.AutoFac/WebApiContrib.IoC.AutoFac.csproj
@@ -70,6 +70,7 @@
   <ItemGroup>
     <Compile Include="AutoFacResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RegistrationExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Added extension method for registering all the Web API controllers automatically in an AutoFac container
