### PR TITLE
WebApiContrib.IoC.CastleWindsor

### DIFF
--- a/WebApiContrib.sln
+++ b/WebApiContrib.sln
@@ -26,7 +26,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.Formatting.ProtoBuf", "src\WebApiContrib.Formatting.ProtoBuf\WebApiContrib.Formatting.ProtoBuf.csproj", "{2537E1C1-0212-4595-9F73-C0DEAE31BD62}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.Testing", "src\WebApiContrib.Testing\WebApiContrib.Testing.csproj", "{DDEB5F68-7E22-4F54-9B04-63518083B83E}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.RavenDb", "src\WebApiContrib.RavenDb\WebApiContrib.RavenDb.csproj", "{3D3C4640-9365-471A-A160-59E7C394B228}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.IoC.CastleWindsor", "src\WebApiContrib.IoC.CastleWindsor\WebApiContrib.IoC.CastleWindsor.csproj", "{3735BC1C-6224-417B-8816-D6BC6498682F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -78,6 +81,10 @@ Global
 		{3D3C4640-9365-471A-A160-59E7C394B228}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3D3C4640-9365-471A-A160-59E7C394B228}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3D3C4640-9365-471A-A160-59E7C394B228}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3735BC1C-6224-417B-8816-D6BC6498682F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3735BC1C-6224-417B-8816-D6BC6498682F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3735BC1C-6224-417B-8816-D6BC6498682F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3735BC1C-6224-417B-8816-D6BC6498682F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/WebApiContrib.IoC.CastleWindsor/Properties/AssemblyInfo.cs
+++ b/src/WebApiContrib.IoC.CastleWindsor/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WebApiContrib.IoC.CastleWindsor")]
+[assembly: AssemblyDescription("The WebApiContrib.IoC.CastleWindsor library provides dependency injection helpers for ASP.NET Web API.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WebApiContrib.IoC.CastleWindsor")]
+[assembly: AssemblyCopyright("Copyright © Richard Dingwall 2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("087a0a37-a64a-41bb-bce6-fb2e2aa1b6a5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/WebApiContrib.IoC.CastleWindsor/WebApiContrib.IoC.CastleWindsor.csproj
+++ b/src/WebApiContrib.IoC.CastleWindsor/WebApiContrib.IoC.CastleWindsor.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{3735BC1C-6224-417B-8816-D6BC6498682F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebApiContrib.IoC.CastleWindsor</RootNamespace>
+    <AssemblyName>WebApiContrib.IoC.CastleWindsor</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\WebAPIContrib\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core">
+      <HintPath>..\..\packages\Castle.Core.3.0.0.4001\lib\net40-client\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Windsor">
+      <HintPath>..\..\packages\Castle.Windsor.3.0.0.4001\lib\net40\Castle.Windsor.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Json">
+      <HintPath>..\..\packages\System.Json.4.0.20126.16343\lib\net40\System.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http">
+      <HintPath>..\..\packages\System.Net.Http.2.0.20126.16343\lib\net40\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting">
+      <HintPath>..\..\packages\System.Net.Http.Formatting.4.0.20126.16343\lib\net40\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest">
+      <HintPath>..\..\packages\System.Net.Http.2.0.20126.16343\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http">
+      <HintPath>..\..\packages\AspNetWebApi.Core.4.0.20126.16343\lib\net40\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Common">
+      <HintPath>..\..\packages\System.Web.Http.Common.4.0.20126.16343\lib\net40\System.Web.Http.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost">
+      <HintPath>..\..\packages\AspNetWebApi.4.0.20126.16343\lib\net40\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WindsorResolver.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/WebApiContrib.IoC.CastleWindsor/WindsorResolver.cs
+++ b/src/WebApiContrib.IoC.CastleWindsor/WindsorResolver.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http.Services;
+using Castle.Windsor;
+
+namespace WebApiContrib.IoC.CastleWindsor
+{
+    public class WindsorResolver : IDependencyResolver
+    {
+        private readonly IWindsorContainer container;
+
+        public WindsorResolver(IWindsorContainer container)
+        {
+            if (container == null) throw new ArgumentNullException("container");
+            this.container = container;
+        }
+
+        public object GetService(Type serviceType)
+        {
+            if (!container.Kernel.HasComponent(serviceType))
+                return null;
+
+            return container.Resolve(serviceType);
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType)
+        {
+            if (!container.Kernel.HasComponent(serviceType))
+                return Enumerable.Empty<object>();
+
+            return container.ResolveAll(serviceType).Cast<object>();
+        }
+    }
+}

--- a/src/WebApiContrib.IoC.CastleWindsor/packages.config
+++ b/src/WebApiContrib.IoC.CastleWindsor/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AspNetWebApi" version="4.0.20126.16343" />
+  <package id="AspNetWebApi.Core" version="4.0.20126.16343" />
+  <package id="Castle.Core" version="3.0.0.4001" />
+  <package id="Castle.Windsor" version="3.0.0.4001" />
+  <package id="System.Json" version="4.0.20126.16343" />
+  <package id="System.Net.Http" version="2.0.20126.16343" />
+  <package id="System.Net.Http.Formatting" version="4.0.20126.16343" />
+  <package id="System.Web.Http.Common" version="4.0.20126.16343" />
+</packages>

--- a/test/WebApiContribTests/IoC/DependencyInjectionTests.cs
+++ b/test/WebApiContribTests/IoC/DependencyInjectionTests.cs
@@ -2,10 +2,13 @@
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using Autofac;
+using Castle.MicroKernel.Registration;
+using Castle.Windsor;
 using Microsoft.Practices.Unity;
 using NUnit.Framework;
 using Ninject;
 using WebApiContrib.IoC.AutoFac;
+using WebApiContrib.IoC.CastleWindsor;
 using WebApiContrib.IoC.Ninject;
 using WebApiContrib.IoC.Unity;
 using WebApiContribTests.Helpers;
@@ -183,6 +186,70 @@ namespace WebApiContribTests.IoC
             var instance = config.ServiceResolver.GetService(typeof(IHttpActionSelector));
 
             Assert.IsNotNull(instance);
+        }
+
+        [Test]
+        public void WindsorResolver_Resolves_Registered_ContactRepository_Test()
+        {
+            using (var container = new WindsorContainer())
+            {
+                container.Register(
+                    Component.For<IContactRepository>().Instance(new InMemoryContactRepository()));
+
+                var resolver = new WindsorResolver(container);
+                var instance = resolver.GetService(typeof (IContactRepository));
+
+                Assert.IsNotNull(instance);
+            }
+        }
+
+        [Test]
+        public void WindsorResolver_DoesNot_Resolve_NonRegistered_ContactRepository_Test()
+        {
+            using (var container = new WindsorContainer())
+            {
+                var resolver = new WindsorResolver(container);
+                var instance = resolver.GetService(typeof (IContactRepository));
+
+                Assert.IsNull(instance);
+            }
+        }
+
+        [Test]
+        public void WindsorResolver_Resolves_Registered_ContactRepository_Through_ContactsController_Test()
+        {
+            var config = new HttpConfiguration();
+            config.Routes.MapHttpRoute("default",
+                "api/{controller}/{id}", new { id = RouteParameter.Optional });
+
+            using (var container = new WindsorContainer())
+            {
+                container.Register(
+                    Component.For<IContactRepository>().Instance(new InMemoryContactRepository()));
+
+                config.ServiceResolver.SetResolver(new WindsorResolver(container));
+
+                var server = new HttpServer(config);
+                var client = new HttpClient(server);
+
+                var response = client.GetAsync("http://anything/api/contacts").Result;
+
+                Assert.IsNotNull(response.Content);
+            }
+        }
+
+        [Test]
+        public void WindsorResolver_In_HttpConfig_DoesNot_Resolve_PipelineType_But_Fallback_To_DefaultResolver_Test()
+        {
+            using (var container = new WindsorContainer())
+            {
+
+                var config = new HttpConfiguration();
+                config.ServiceResolver.SetResolver(new WindsorResolver(container));
+                var instance = config.ServiceResolver.GetService(typeof (IHttpActionSelector));
+
+                Assert.IsNotNull(instance);
+            }
         }
     }
 }

--- a/test/WebApiContribTests/WebApiContribTests.csproj
+++ b/test/WebApiContribTests/WebApiContribTests.csproj
@@ -36,6 +36,15 @@
     <Reference Include="Autofac">
       <HintPath>..\..\packages\Autofac.2.6.1.841\lib\NET40\Autofac.dll</HintPath>
     </Reference>
+    <Reference Include="Castle.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.3.0.0.4001\lib\net40-client\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Windsor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Windsor.3.0.0.4001\lib\net40\Castle.Windsor.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.ServiceLocation">
+      <HintPath>..\..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.Unity">
       <HintPath>..\..\packages\Unity.2.1.505.0\lib\NET35\Microsoft.Practices.Unity.dll</HintPath>
     </Reference>
@@ -122,6 +131,10 @@
     <ProjectReference Include="..\..\src\WebApiContrib.IoC.AutoFac\WebApiContrib.IoC.AutoFac.csproj">
       <Project>{AA772346-54BD-48C4-AEC0-CCF54A7E45FF}</Project>
       <Name>WebApiContrib.IoC.AutoFac</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\WebApiContrib.IoC.CastleWindsor\WebApiContrib.IoC.CastleWindsor.csproj">
+      <Project>{3735BC1C-6224-417B-8816-D6BC6498682F}</Project>
+      <Name>WebApiContrib.IoC.CastleWindsor</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\WebApiContrib.IoC.Ninject\WebApiContrib.IoC.Ninject.csproj">
       <Project>{7AFAC6AB-9B5F-41B7-9AB7-84053FC19A7E}</Project>

--- a/test/WebApiContribTests/packages.config
+++ b/test/WebApiContribTests/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AspNetWebApi.Core" version="4.0.20126.16343" />
+  <package id="Castle.Core" version="3.0.0.4001" />
+  <package id="Castle.Windsor" version="3.0.0.4001" />
+  <package id="CommonServiceLocator" version="1.0" />
   <package id="NUnit" version="2.6.0.12054" />
   <package id="NUnit.Runners" version="2.6.0.12051" />
   <package id="RhinoMocks" version="3.6" />


### PR DESCRIPTION
Hey here's a patch to add a new dependency resolver for Castle Windsor. (Tests included). It's ported from my own app, where I've been using it for a couple of months.

PS I noticed some of the AssemblyInfo's in the Ninject, AutoFac and Unity resolver projects have AssemblyTitle and AssemblyProduct still set to Thinktecture.x.y.z.
