### PR TITLE
added RouteDataMapping MediaTypeMapping

### DIFF
--- a/src/WebApiContrib/Formatting/RouteDataMapping.cs
+++ b/src/WebApiContrib/Formatting/RouteDataMapping.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Net.Http.Formatting;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web.Http;
+
+namespace WebApiContrib.Formatting {
+
+    public class RouteDataMapping : MediaTypeMapping
+    {
+        private readonly string _routeDataValueName;
+        private readonly string _routeDataValueValue;
+
+        public RouteDataMapping(string routeDataValueName, string routeDataValueValue, MediaTypeHeaderValue mediaType) 
+            : base(mediaType) 
+        {
+            _routeDataValueName = routeDataValueName;
+            _routeDataValueValue = routeDataValueValue;
+        }
+
+        public RouteDataMapping(string routeDataValueName, string routeDataValueValue, string mediaType) 
+            : base(mediaType) 
+        {
+            _routeDataValueName = routeDataValueName;
+            _routeDataValueValue = routeDataValueValue;
+        }
+
+        protected override double OnTryMatchMediaType(HttpResponseMessage response) 
+        {
+            return (
+                response.RequestMessage.GetRouteData().Values[_routeDataValueName].ToString() == _routeDataValueValue
+            ) ? 1.0 : 0.0;
+        }
+
+        //Don't use this
+        //This will be removed on the first drop
+        protected override double OnTryMatchMediaType(HttpRequestMessage request) 
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/WebApiContrib/WebApiContrib.csproj
+++ b/src/WebApiContrib/WebApiContrib.csproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Formatting\JsonpFormatter.cs" />
+    <Compile Include="Formatting\RouteDataMapping.cs" />
     <Compile Include="Internal\MediaTypeConstants.cs" />
     <Compile Include="Conneg\ContentNegotiation.cs" />
     <Compile Include="Content\CompressedContent.cs" />


### PR DESCRIPTION
Implemented `RouteDataMapping` `MediaTypeMapping`.

Sample usage:

Add a route which satisfies our needs:

```
GlobalConfiguration.Configuration.Routes.MapHttpRoute(
    "defaultHttpRoute",
    routeTemplate: "api/{controller}.{extension}",
    defaults: new { },
    constraints: new { extension = "json|xml" }
);
```

Add the `RouteDataMapping` instance to formatters:

```
GlobalConfiguration.Configuration.Formatters.JsonFormatter.
    MediaTypeMappings.Add(
        new RouteDataMapping(
            "extension", "json", "application/json"
    )
);

GlobalConfiguration.Configuration.Formatters.XmlFormatter.
    MediaTypeMappings.Add(
        new RouteDataMapping(
            "extension", "xml", "application/xml"
    )
);
```

For more information on `RouteDataMapping`:

[ASP.NET Web API Custom RouteDataMapping (MediaTypeMapping)](http://www.tugberkugurlu.com/archive/asp-net-web-api-custom-routedatamapping-mediatypemapping)
