### PR TITLE
Added WebApiContrib.IoC.StructureMap

### DIFF
--- a/WebApiContrib.sln
+++ b/WebApiContrib.sln
@@ -30,7 +30,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.RavenDb", "src\WebApiContrib.RavenDb\WebApiContrib.RavenDb.csproj", "{3D3C4640-9365-471A-A160-59E7C394B228}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.Formatting.RazorViewEngine", "src\WebApiContrib.Formatting.RazorViewEngine\WebApiContrib.Formatting.RazorViewEngine.csproj", "{75FA4F0E-ACC6-424A-8809-B25E7AB17EFE}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.IoC.CastleWindsor", "src\WebApiContrib.IoC.CastleWindsor\WebApiContrib.IoC.CastleWindsor.csproj", "{3735BC1C-6224-417B-8816-D6BC6498682F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.IoC.StructureMap", "src\WebApiContrib.IoC.StructureMap\WebApiContrib.IoC.StructureMap.csproj", "{B295E165-A947-4027-8245-02AB24C7E840}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -90,6 +93,10 @@ Global
 		{3735BC1C-6224-417B-8816-D6BC6498682F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3735BC1C-6224-417B-8816-D6BC6498682F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3735BC1C-6224-417B-8816-D6BC6498682F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B295E165-A947-4027-8245-02AB24C7E840}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B295E165-A947-4027-8245-02AB24C7E840}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B295E165-A947-4027-8245-02AB24C7E840}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B295E165-A947-4027-8245-02AB24C7E840}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/WebApiContrib.IoC.StructureMap/Properties/AssemblyInfo.cs
+++ b/src/WebApiContrib.IoC.StructureMap/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WebApiContrib.IoC.StructureMap")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WebApiContrib.IoC.StructureMap")]
+[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cdaede1c-c0e2-4b35-bedf-4def04e8141b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/WebApiContrib.IoC.StructureMap/StructureMapResolver.cs
+++ b/src/WebApiContrib.IoC.StructureMap/StructureMapResolver.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
+using System.Web.Http.Services;
+using StructureMap;
+
+namespace WebApiContrib.IoC.StructureMap
+{
+    public class StructureMapResolver : IDependencyResolver, IHttpControllerActivator
+    {
+        private readonly IContainer container;
+
+        public StructureMapResolver(IContainer container)
+        {
+            if (container == null)
+                throw new ArgumentNullException("container");
+
+            this.container = container;
+
+            this.container.Inject(typeof(IHttpControllerActivator), this);
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return container.TryGetInstance(serviceType);
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType)
+        {
+            return container.GetAllInstances(serviceType).Cast<object>();
+        }
+
+        public IHttpController Create(HttpControllerContext controllerContext, Type controllerType)
+        {
+            return (IHttpController) container.GetInstance(controllerType);
+        }
+    }
+}

--- a/src/WebApiContrib.IoC.StructureMap/WebApiContrib.IoC.StructureMap.csproj
+++ b/src/WebApiContrib.IoC.StructureMap/WebApiContrib.IoC.StructureMap.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{B295E165-A947-4027-8245-02AB24C7E840}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebApiContrib.IoC.StructureMap</RootNamespace>
+    <AssemblyName>WebApiContrib.IoC.StructureMap</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\WebAPIContrib\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="StructureMap">
+      <HintPath>..\..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\System.Net.Http.2.0.20126.16343\lib\net40\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\System.Net.Http.Formatting.4.0.20126.16343\lib\net40\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\System.Net.Http.2.0.20126.16343\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\AspNetWebApi.Core.4.0.20126.16343\lib\net40\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\System.Web.Http.Common.4.0.20126.16343\lib\net40\System.Web.Http.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StructureMapResolver.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/WebApiContrib.IoC.StructureMap/packages.config
+++ b/src/WebApiContrib.IoC.StructureMap/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AspNetWebApi.Core" version="4.0.20126.16343" />
+  <package id="structuremap" version="2.6.3" />
+  <package id="System.Net.Http" version="2.0.20126.16343" />
+  <package id="System.Net.Http.Formatting" version="4.0.20126.16343" />
+  <package id="System.Web.Http.Common" version="4.0.20126.16343" />
+</packages>

--- a/test/WebApiContribTests/Helpers/InMemoryContactRepository.cs
+++ b/test/WebApiContribTests/Helpers/InMemoryContactRepository.cs
@@ -1,5 +1,9 @@
 namespace WebApiContribTests.Helpers
 {
+    public class FileContactRepository : IContactRepository
+    {
+    }
+
     public class InMemoryContactRepository : IContactRepository
     {
     }

--- a/test/WebApiContribTests/WebApiContribTests.csproj
+++ b/test/WebApiContribTests/WebApiContribTests.csproj
@@ -62,6 +62,9 @@
     <Reference Include="Should">
       <HintPath>..\..\packages\Should.1.1.12.0\lib\Should.dll</HintPath>
     </Reference>
+    <Reference Include="StructureMap">
+      <HintPath>..\..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Json">
@@ -147,6 +150,10 @@
     <ProjectReference Include="..\..\src\WebApiContrib.IoC.Ninject\WebApiContrib.IoC.Ninject.csproj">
       <Project>{7AFAC6AB-9B5F-41B7-9AB7-84053FC19A7E}</Project>
       <Name>WebApiContrib.IoC.Ninject</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\WebApiContrib.IoC.StructureMap\WebApiContrib.IoC.StructureMap.csproj">
+      <Project>{B295E165-A947-4027-8245-02AB24C7E840}</Project>
+      <Name>WebApiContrib.IoC.StructureMap</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\WebApiContrib.IoC.Unity\WebApiContrib.IoC.Unity.csproj">
       <Project>{543DD4BC-C610-4381-82D9-2BA3686AEE0F}</Project>


### PR DESCRIPTION
You'll notice something a little bit different, but having the `StructureMapResolver` implement `IHttpControllerActivator` allows the class to inject itself into the container, then everything else that relies on `WithDefaultConventions` "just works". Without it one would have to register their own class and this makes the usage much simpler. Thoughts?
