### PR TITLE
Added Extension to HttpConfiguration to use web.config custom errors

### DIFF
--- a/src/WebApiContrib/Configuration/ConfigurationExtensions.cs
+++ b/src/WebApiContrib/Configuration/ConfigurationExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Configuration;
+using System.Web.Configuration;
+using System.Web.Http;
+
+namespace WebApiContrib.Configuration
+{
+    public static class ConfigurationExtensions
+    {
+        private static readonly IDictionary<CustomErrorsMode, IncludeErrorDetailPolicy> policyLookup = new Dictionary<CustomErrorsMode, IncludeErrorDetailPolicy>
+                            {
+                                { CustomErrorsMode.RemoteOnly, IncludeErrorDetailPolicy.LocalOnly },
+                                { CustomErrorsMode.On, IncludeErrorDetailPolicy.Never },
+                                { CustomErrorsMode.Off, IncludeErrorDetailPolicy.Always },
+                            };
+
+        public static void UseWebConfigCustomErrors(this HttpConfiguration configuration)
+        {
+            var config = (CustomErrorsSection)ConfigurationManager.GetSection("system.web/customErrors");
+
+            configuration.IncludeErrorDetailPolicy = policyLookup[config.Mode];
+        }
+    }
+}

--- a/src/WebApiContrib/WebApiContrib.csproj
+++ b/src/WebApiContrib/WebApiContrib.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.ServiceModel" />
@@ -65,6 +66,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\ConfigurationExtensions.cs" />
     <Compile Include="Formatting\CSVMediaTypeFormatter.cs" />
     <Compile Include="Formatting\JsonpFormatter.cs" />
     <Compile Include="Formatting\PlainTextFormatter.cs" />


### PR DESCRIPTION
This extension addresses this perfectly:

http://lostechies.com/jimmybogard/2012/04/18/custom-errors-and-error-detail-policy-in-asp-net-web-api/
