### PR TITLE
Added BasicAuthenticationHandler and RequireHttpsHandler

### DIFF
--- a/src/WebApiContrib/MessageHandlers/BasicAuthenticationHandler.cs
+++ b/src/WebApiContrib/MessageHandlers/BasicAuthenticationHandler.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebApiContrib.MessageHandlers
+{
+    public abstract class BasicAuthenticationHandler : DelegatingHandler
+    {
+        protected abstract bool Authorize(string username, string password);
+
+        protected abstract string Realm { get; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            if (request.Headers.Authorization != null && request.Headers.Authorization.Scheme == "Basic")
+            {
+                var credentials = ParseCredentials(request.Headers.Authorization);
+
+                if (Authorize(credentials.Username, credentials.Password))
+                {
+                    return base.SendAsync(request, cancellationToken);
+                }
+            }
+
+            return Task<HttpResponseMessage>.Factory.StartNew(
+                () =>
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+                    response.Headers.Add("WWW-Authenticate", string.Format("Basic realm=\"{0}\"", Realm));
+
+                    return response;
+                });
+        }
+
+        private static BasicCredentials ParseCredentials(AuthenticationHeaderValue authHeader)
+        {
+            try
+            {
+                var credentials = Encoding.ASCII.GetString(Convert.FromBase64String(authHeader.ToString().Substring(6))).Split(':');
+
+                return new BasicCredentials
+                {
+                    Username = credentials[0],
+                    Password = credentials[1]
+                };
+            }
+            catch { }
+
+            return new BasicCredentials();
+        }
+
+        internal struct BasicCredentials
+        {
+            public string Username { get; set; }
+            public string Password { get; set; }
+        }
+    }
+}

--- a/src/WebApiContrib/MessageHandlers/RequireHttpsHandler.cs
+++ b/src/WebApiContrib/MessageHandlers/RequireHttpsHandler.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace WebApiContrib.MessageHandlers
+{
+    public class RequireHttpsHandler : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            if (request.RequestUri.Scheme != Uri.UriSchemeHttps)
+            {
+                return Task<HttpResponseMessage>.Factory.StartNew(
+                    () => new HttpResponseMessage(HttpStatusCode.Forbidden) { Content = new StringContent("SSL is required.") });
+            }
+
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/WebApiContrib/WebApiContrib.csproj
+++ b/src/WebApiContrib/WebApiContrib.csproj
@@ -80,11 +80,13 @@
     <Compile Include="Formatting\ReadWriteFormUrlEncodedFormatter.cs" />
     <Compile Include="Internal\Extensions\EnumerableExtensions.cs" />
     <Compile Include="Internal\ReflectionHelper.cs" />
+    <Compile Include="MessageHandlers\BasicAuthenticationHandler.cs" />
     <Compile Include="MessageHandlers\EncodingHandler.cs" />
     <Compile Include="MessageHandlers\ETagHandler.cs" />
     <Compile Include="MessageHandlers\LoggingHandler.cs" />
     <Compile Include="MessageHandlers\MethodOverrideHandler.cs" />
     <Compile Include="MessageHandlers\NotAcceptableMessageHandler.cs" />
+    <Compile Include="MessageHandlers\RequireHttpsHandler.cs" />
     <Compile Include="MessageHandlers\SimpleCorsHandler.cs" />
     <Compile Include="MessageHandlers\UriFormatExtensionHandler.cs" />
     <Compile Include="Messages\ApiLoggingInfo.cs" />


### PR DESCRIPTION
The RequireHttpsHandler is simple: It checks that request.RequestUri.Scheme is of Https and returns a Forbidden response if not.

BasicAuthenticationHandler is an abstract class that would be implemented like so:

```
public class MyBasicAuthHandler : BasicAuthenticationHandler
{
    protected override bool Authorize(string username, string password)
    {
        //my code to determine if credentials are valid
        return username == "user" && password == "expectedpassword";
    }

    protected override string Realm
    {
        get { return "whatever"; }
    }
}
```

If Authorize() returned false here then the response generated would be 401 with the header:

```
WWW-Authenticate: Basic realm="whatever"
```

My understanding is that realm is required, hence the mandate on overriding it. You can supply a null value and it'll be set to an empty string.
