### PR TITLE
Updated the NotAcceptableMessageHandler and tests to use WebAPI method for detecting wildcard content type matches

### DIFF
--- a/test/WebApiContribTests/MessageHandlers/NotAcceptableMessageHandlerTests.cs
+++ b/test/WebApiContribTests/MessageHandlers/NotAcceptableMessageHandlerTests.cs
@@ -5,6 +5,7 @@ using System.Web.Http;
 using NUnit.Framework;
 using WebApiContrib.MessageHandlers;
 using Should;
+using System.Net.Http.Formatting;
 
 namespace WebApiContribTests.MessageHandlers
 {
@@ -40,7 +41,15 @@ namespace WebApiContribTests.MessageHandlers
         [Test]
         public void Should_return_OK_when_type_group_is_accepted()
         {
-            var notAcceptableMessageHandler = new NotAcceptableMessageHandler(new HttpConfiguration());
+            var config = new HttpConfiguration();
+
+            var customXmlFormatter = new XmlMediaTypeFormatter();
+            customXmlFormatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue("text/vnd.webapi.contrib+xml"));
+            customXmlFormatter.AddMediaRangeMapping(new MediaTypeHeaderValue("text/*"), new MediaTypeHeaderValue("text/vnd.webapi.contrib+xml"));
+
+            config.Formatters.Add(customXmlFormatter);
+
+            var notAcceptableMessageHandler = new NotAcceptableMessageHandler(config);
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Get, "foo/bar");
             requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/*"));
@@ -66,7 +75,15 @@ namespace WebApiContribTests.MessageHandlers
         [Test] 
         public void Should_return_OK_when_all_media_types_is_accepted()
         {
-            var notAcceptableMessageHandler = new NotAcceptableMessageHandler(new HttpConfiguration());
+            var config = new HttpConfiguration();
+
+            var customXmlFormatter = new XmlMediaTypeFormatter();
+            customXmlFormatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/vnd.webapi.contrib+xml"));
+            customXmlFormatter.AddMediaRangeMapping(new MediaTypeHeaderValue("*/*"), new MediaTypeHeaderValue("application/vnd.webapi.contrib+xml"));
+
+            config.Formatters.Add(customXmlFormatter);
+
+            var notAcceptableMessageHandler = new NotAcceptableMessageHandler(config);
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Get, "foo/bar");
             requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
@@ -93,8 +110,16 @@ namespace WebApiContribTests.MessageHandlers
         [Test]
         public void Should_return_OK_when_one_of_the_media_types_is_a_accepted_type_group()
         {
-            var notAcceptableMessageHandler = new NotAcceptableMessageHandler(new HttpConfiguration());
+            var config  = new HttpConfiguration();
+            
+            var customXmlFormatter = new XmlMediaTypeFormatter();
+            customXmlFormatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/vnd.webapi.contrib+xml"));
+            customXmlFormatter.AddMediaRangeMapping(new MediaTypeHeaderValue("application/*"),new MediaTypeHeaderValue("application/vnd.webapi.contrib+xml"));
 
+            config.Formatters.Add(customXmlFormatter);
+
+            var notAcceptableMessageHandler = new NotAcceptableMessageHandler(config);
+         
             var requestMessage = new HttpRequestMessage(HttpMethod.Get, "foo/bar");
             requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("weird/type"));
             requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/*"));
@@ -107,7 +132,15 @@ namespace WebApiContribTests.MessageHandlers
         [Test]
         public void Should_return_OK_when_one_of_the_media_types_is_all_media_types()
         {
-            var notAcceptableMessageHandler = new NotAcceptableMessageHandler(new HttpConfiguration());
+            var config  = new HttpConfiguration();
+            
+            var customXmlFormatter = new XmlMediaTypeFormatter();
+            customXmlFormatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/vnd.webapi.contrib+xml"));
+            customXmlFormatter.AddMediaRangeMapping(new MediaTypeHeaderValue("*/*"),new MediaTypeHeaderValue("application/vnd.webapi.contrib+xml"));
+
+            config.Formatters.Add(customXmlFormatter);
+
+            var notAcceptableMessageHandler = new NotAcceptableMessageHandler(config);
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Get, "foo/bar");
             requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("weird/type"));


### PR DESCRIPTION
Manually detecting the wildcard mappings causes the request to be
processed but does not match the expected content type and instead falls
through to the default application/json
