### PR TITLE
Added Route Testing

### DIFF
--- a/src/WebApiContrib.Testing/Assert.cs
+++ b/src/WebApiContrib.Testing/Assert.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Text;
+
+namespace WebApiContrib.Testing
+{
+    /// <summary>
+    /// Test framework agnostic assertions
+    /// </summary>
+    internal static class Assert
+    {
+        /// <summary>
+        /// Assert that the value is true
+        /// </summary>
+        /// <param name="actual">The actual value</param>
+        /// <param name="message">Message to display when assertion fails</param>
+        /// <exception cref="WebApiContrib.Testing.AssertionException"></exception>
+        public static void IsTrue(bool actual, string message = null)
+        {
+            if(actual)
+                return;
+
+            string errorMessage = BuildErrorMessage("Expected the value to be true", message);
+            throw new AssertionException(errorMessage);
+        }
+
+        /// <summary>
+        /// Asserts that the object is not null
+        /// </summary>
+        /// <param name="actual">The actual value</param>
+        /// <param name="message">Message to display when assertion fails</param>
+        /// <exception cref="WebApiContrib.Testing.AssertionException"></exception>
+        public static void IsNotNull(object actual, string message = null)
+        {
+            if(actual != null)
+                return;
+
+            string errorMessage = BuildErrorMessage("Expected the value to not be null", message);
+            throw new AssertionException(errorMessage);
+        }
+
+        /// <summary>
+        /// Asserts that the object is of type T
+        /// </summary>
+        /// <typeparam name="T">The expected type</typeparam>
+        /// <param name="actual">The actual instance</param>
+        /// <param name="message">Message to display when assertion fails</param>
+        /// <exception cref="WebApiContrib.Testing.AssertionException"></exception>
+        public static T InstanceOf<T>(object actual, string message = null)
+            where T : class
+        {
+            var actualT = actual as T;
+            if(actualT != null)
+                return actualT;
+
+            string expectedType = typeof(T).FullName;
+            string actualType = actual == null ? "null" : actual.GetType().FullName;
+            string errorMessage = BuildErrorMessage(expectedType, actualType, message);
+            throw new AssertionException(errorMessage);
+        }
+
+        /// <summary>
+        /// Asserts that the object is the expected value
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The actual value</param>
+        /// <param name="message">Message to display when assertion fails</param>
+        /// <exception cref="WebApiContrib.Testing.AssertionException"></exception>
+        public static void AreEqual(object expected, object actual, string message = null)
+        {
+            if(Equals(actual, expected))
+                return;
+
+            string errorMessage = BuildErrorMessage(expected, actual, message);
+            throw new AssertionException(errorMessage);
+        }
+
+        /// <summary>
+        /// Compares the two strings (culture and case-insensitive).
+        /// </summary>
+        /// <param name="expected">The expected string.</param>
+        /// <param name="actual">The actual string.</param>
+        /// <param name="message">Message to display when assertion fails</param>
+        /// <exception cref="WebApiContrib.Testing.AssertionException"></exception>
+        public static void AreSameString(string expected, string actual, string message = null)
+        {
+            if(string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            string errorMessage = BuildErrorMessage(expected, actual, message);
+            throw new AssertionException(errorMessage);
+        }
+
+        private static string BuildErrorMessage(string assertionMessage, string message)
+        {
+            var exceptionMessage = new StringBuilder();
+            exceptionMessage.AppendLine(assertionMessage);
+            if(message != null)
+            {
+                exceptionMessage.AppendLine(message);
+            }
+
+            return exceptionMessage.ToString();
+        }
+
+        private static string BuildErrorMessage(object expected, object actual, string message)
+        {
+            string actualValue = actual != null ? actual.ToString() : "null";
+            string expectedValue = expected != null ? expected.ToString() : "null";
+
+            var exceptionMessage = new StringBuilder();
+            exceptionMessage.AppendFormat("was {0} but expected {1}", actualValue, expectedValue);
+            if(message != null)
+            {
+                exceptionMessage.AppendLine();
+                exceptionMessage.AppendLine(message);
+            }
+
+            return exceptionMessage.ToString();
+        }
+    }
+}

--- a/src/WebApiContrib.Testing/AssertionException.cs
+++ b/src/WebApiContrib.Testing/AssertionException.cs
@@ -1,0 +1,41 @@
+﻿// http://mvccontrib.codeplex.com
+// Copyright 2007-2010 Eric Hexter, Jeffrey Palermo
+
+using System;
+using System.Linq;
+
+namespace WebApiContrib.Testing
+{
+    ///<summary>
+    /// This exception is thrown by the Testing extension methods.  This allows this project to be unit test framework agnostic.
+    ///</summary>
+    public class AssertionException : Exception
+    {
+        public AssertionException(string message)
+            : base(message)
+        {
+        }
+
+        public override string StackTrace
+        {
+            get
+            {
+                string Namespace = GetType().Namespace;
+                var stacktracestring = SplitTheStackTraceByEachNewLine()
+                    .Where(s => !s.TrimStart(' ').StartsWith("at " + Namespace))
+                    .ToArray();
+                return JoinArrayWithNewLineCharacters(stacktracestring);
+            }
+        }
+
+        private string[] SplitTheStackTraceByEachNewLine()
+        {
+            return base.StackTrace.Split(new[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        private static string JoinArrayWithNewLineCharacters(string[] stacktracestring)
+        {
+            return string.Join(Environment.NewLine, stacktracestring);
+        }
+    }
+}

--- a/src/WebApiContrib.Testing/Internal/Extensions/MemberInfoExtensions.cs
+++ b/src/WebApiContrib.Testing/Internal/Extensions/MemberInfoExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace WebApiContrib.Testing.Internal.Extensions
+{
+    internal static class MemberInfoExtensions
+    {
+        public static IEnumerable<T> GetAttribute<T>(this MemberInfo member)
+            where T : class
+        {
+            return GetAttribute(member, typeof(T)).OfType<T>();
+        }
+
+        public static IEnumerable<object> GetAttribute(this MemberInfo member, Type attributeType)
+        {
+            return member.GetCustomAttributes(attributeType, true);
+        }
+
+        public static bool HasAttribute<T>(this MemberInfo member)
+            where T : class
+        {
+            return HasAttribute(member, typeof(T));
+        }
+
+        public static bool HasAttribute(this MemberInfo member, Type attributeType)
+        {
+            return member.GetAttribute(attributeType).Any();
+        }
+    }
+}

--- a/src/WebApiContrib.Testing/Internal/Extensions/MethodInfoExtensions.cs
+++ b/src/WebApiContrib.Testing/Internal/Extensions/MethodInfoExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Modified from http://mvccontrib.codeplex.com
+// Copyright 2007-2010 Eric Hexter, Jeffrey Palermo
+
+using System.Linq;
+using System.Reflection;
+using System.Web.Http;
+
+namespace WebApiContrib.Testing.Internal.Extensions
+{
+    internal static class MethodInfoExtensions
+    {
+        /// <summary>
+        /// Returns the name of the action specified in the ActionNameAttribute or the name of the method if no attribute is present.
+        /// </summary>
+        /// <param name="method"></param>
+        public static string ActionName(this MethodInfo method)
+        {
+            if (method.HasAttribute<ActionNameAttribute>())
+                return method.GetAttribute<ActionNameAttribute>().First().Name;
+
+            return method.Name;
+        }
+    }
+}

--- a/src/WebApiContrib.Testing/Internal/Extensions/TypeExtensions.cs
+++ b/src/WebApiContrib.Testing/Internal/Extensions/TypeExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace WebApiContrib.Testing.Internal.Extensions
+{
+    internal static class TypeExtensions
+    {
+        public static Type GetTypeFromNullable(this Type type)
+        {
+            if (!type.IsGenericType)
+                return type;
+
+            if (type.GetGenericTypeDefinition() != typeof(Nullable<>))
+                return type;
+
+            return type.GetGenericArguments()[0];
+        }
+
+        public static object GetDefault(this Type type)
+        {
+            return typeof(TypeExtensions).GetMethod("GetDefaultGeneric").MakeGenericMethod(type).Invoke(null, null);
+        }
+
+        public static T GetDefaultGeneric<T>()
+        {
+            return default(T);
+        }
+    }
+}

--- a/src/WebApiContrib.Testing/WebApiContrib.Testing.csproj
+++ b/src/WebApiContrib.Testing/WebApiContrib.Testing.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\WebApiContrib.Testing.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,11 +38,12 @@
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="MvcContrib.TestHelper">
-      <HintPath>..\..\packages\MvcContrib.Mvc3.TestHelper-ci.3.0.100.0\lib\MvcContrib.TestHelper.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.4.5.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -58,12 +60,16 @@
     <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.4.0.20710.0\lib\net40\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssertionException.cs" />
     <Compile Include="DummyLoggingRepository.cs" />
     <Compile Include="FakeController.cs" />
     <Compile Include="FakeHandler.cs" />
+    <Compile Include="Assert.cs" />
+    <Compile Include="Internal\Extensions\MemberInfoExtensions.cs" />
+    <Compile Include="Internal\Extensions\MethodInfoExtensions.cs" />
+    <Compile Include="Internal\Extensions\TypeExtensions.cs" />
     <Compile Include="RouteTestingExtensions.cs" />
     <Compile Include="TestFactory.cs" />
   </ItemGroup>

--- a/src/WebApiContrib.Testing/packages.config
+++ b/src/WebApiContrib.Testing/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
-  <package id="MvcContrib.Mvc3.TestHelper-ci" version="3.0.100.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="4.5.8" targetFramework="net40" />
+  <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
 </packages>

--- a/test/WebApiContribTests/Testing/RouteTestingExtensionsTests.cs
+++ b/test/WebApiContribTests/Testing/RouteTestingExtensionsTests.cs
@@ -3,7 +3,6 @@ using System.Web.Http;
 using System.Web.Routing;
 using NUnit.Framework;
 using WebApiContrib.Testing;
-using HttpVerbs = System.Web.Mvc.HttpVerbs;
 
 namespace WebApiContribTests.Testing
 {
@@ -12,6 +11,11 @@ namespace WebApiContribTests.Testing
     {
         public class SampleController : ApiController
         {
+            public string Get()
+            {
+                return string.Empty;
+            }
+
             public string Get(int id)
             {
                 return "Sample Data";
@@ -34,11 +38,44 @@ namespace WebApiContribTests.Testing
                 return new List<string>();
             }
         }
+        
+        public class FoobarController : ApiController
+        {
+            public List<int> Get()
+            {
+                return new List<int>();
+            }
+
+            public List<int> Get(int id)
+            {
+                return new List<int>();
+            }
+        }
+
+        public class RestfulController : ApiController
+        {
+            public List<int> Get()
+            {
+                return new List<int>();
+            }
+
+            public List<int> Get(int id)
+            {
+                return new List<int>();
+            }
+        }
 
         private static class SampleRouteConfig
         {
             public static void RegisterRoutes(RouteCollection routes)
             {
+                // GET|PUT|DELETE /api/foobar/{id}
+                routes.MapHttpRoute(
+                    name: "Restful Web API",
+                    routeTemplate: "api/restful/{id}",
+                    defaults: new {id = RouteParameter.Optional}
+                    );
+
                 // GET /api/{resource}/{action}
                 routes.MapHttpRoute(
                     name: "Web API RPC",
@@ -47,7 +84,7 @@ namespace WebApiContribTests.Testing
                     constraints: new {action = @"[A-Za-z]+", httpMethod = new HttpMethodConstraint("GET")}
                     );
 
-                // GET|PUT|DELETE /api/{resource}/id
+                // GET|PUT|DELETE /api/{resource}/{id}
                 routes.MapHttpRoute(
                     name: "Web API Resource",
                     routeTemplate: "api/{controller}/{id}",
@@ -81,7 +118,14 @@ namespace WebApiContribTests.Testing
         }
 
         [Test]
-        public void ShouldMapTo_Get()
+        public void ShouldMapTo_WithDefaultAction()
+        {
+            const string url = "~/api/sample/";
+            url.ShouldMapTo<SampleController>(x => x.Get());
+        }
+
+        [Test]
+        public void ShouldMapTo_WithRequiredParameter()
         {
             const string url = "~/api/sample/5";
             url.ShouldMapTo<SampleController>(x => x.Get(5));
@@ -98,7 +142,61 @@ namespace WebApiContribTests.Testing
         public void ShouldMapTo_Post()
         {
             const string url = "~/api/sample";
-            url.ShouldMapTo<SampleController>(x => x.Post(null), HttpVerbs.Post);
+            url.ShouldMapTo<SampleController>(x => x.Post(null), "POST");
+        }
+
+        [Test]
+        [ExpectedException(typeof(WebApiContrib.Testing.AssertionException))]
+        public void ShouldMapTo_ThrowsException_WhenControllerIsIncorrect()
+        {
+            const string url = "~/api/foobar";
+            url.ShouldMapTo<SampleController>(x => x.Get());
+        }
+
+        [Test]
+        [ExpectedException(typeof(WebApiContrib.Testing.AssertionException))]
+        public void ShouldMapTo_ThrowsException_WhenActionIsIncorrect()
+        {
+            const string url = "~/api/sample";
+            url.ShouldMapTo<SampleController>(x => x.Get(), "POST");
+        }
+
+        [Test]
+        [ExpectedException(typeof(WebApiContrib.Testing.AssertionException))]
+        public void ShouldMapTo_ThrowsException_WhenRequiredParameterIsMissing()
+        {
+            const string url = "~/api/sample";
+            url.ShouldMapTo<SampleController>(x => x.Post("abc"), "POST");
+        }
+
+        [Test]
+        [ExpectedException(typeof(WebApiContrib.Testing.AssertionException))]
+        public void ShouldMapTo_ThrowsException_WhenParameterIsIncorrect()
+        {
+            const string url = "~/api/sample/30";
+            url.ShouldMapTo<SampleController>(x => x.Get(15));
+        }
+
+        [Test]
+        public void ShouldMapTo_AllowsOptionalParametersToBeMissing()
+        {
+            const string url = "~/api/foobar";
+            url.ShouldMapTo<FoobarController>(x => x.Get());
+        }
+
+        [Test]
+        public void ShouldMapTo_AllowsOptionalParametersToBeSpecified()
+        {
+            const string url = "~/api/foobar/20";
+            url.ShouldMapTo<FoobarController>(x => x.Get(20));
+        }
+
+        [Test]
+        [ExpectedException(typeof(WebApiContrib.Testing.AssertionException))]
+        public void ShouldMapTo_ThrowsExceptionWhenOptionalParameterIsIncorrect()
+        {
+            const string url = "~/api/foobar/10";
+            url.ShouldMapTo<FoobarController>(x => x.Get(20));
         }
 
         [Test]

--- a/test/WebApiContribTests/WebApiContribTests.csproj
+++ b/test/WebApiContribTests/WebApiContribTests.csproj
@@ -41,6 +41,7 @@
       <HintPath>..\..\packages\NUnit.2.6.1\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="Should">
@@ -67,7 +68,6 @@
     <Reference Include="System.Web.Http.WebHost, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.4.0.20710.0\lib\net40\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/WebApiContribTests/packages.config
+++ b/test/WebApiContribTests/packages.config
@@ -9,6 +9,6 @@
   <package id="Newtonsoft.Json" version="4.5.8" targetFramework="net40" />
   <package id="NUnit" version="2.6.1" targetFramework="net40" />
   <package id="NUnit.Runners" version="2.6.0.12051" />
-  <package id="RhinoMocks" version="3.6.1" />
+  <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
   <package id="Should" version="1.1.12.0" />
 </packages>


### PR DESCRIPTION
This is a modified version of [MvcContrib](http://mvccontrib.codeplex.com/) RouteTestingExtensions which works with Web API controllers. It allows you to assert that a url is routed to the appropriate controller and action.

```
const string url = "~/api/sample/mine";
url.ShouldMapTo<SampleController>(x => x.Mine());
```
