### PR TITLE
Fixed InvalidCastException

### DIFF
--- a/src/WebApiContrib.Testing/RouteTestingExtensions.cs
+++ b/src/WebApiContrib.Testing/RouteTestingExtensions.cs
@@ -37,7 +37,7 @@ namespace WebApiContrib.Testing
         /// <param name="relativeUrl">The url to verify</param>
         /// <param name="action">The expected action that the url should map to</param>
         /// <param name="httpMethod">The HTTP method, e.g. Get, Post, Put, Delete</param>
-        public static RouteData ShouldMapTo<TController>(this string relativeUrl, Expression<Func<TController, object>> action, string httpMethod = "GET") where TController : ApiController
+        public static RouteData ShouldMapTo<TController>(this string relativeUrl, Expression<Action<TController>> action, string httpMethod = "GET") where TController : ApiController
         {
             return relativeUrl.Route(httpMethod).ShouldMapTo(action, httpMethod);
         }
@@ -58,7 +58,7 @@ namespace WebApiContrib.Testing
             return routeData;
         }
 
-        private static RouteData ShouldMapTo<TController>(this RouteData routeData, Expression<Func<TController, object>> action, string httpMethod) where TController : ApiController
+        private static RouteData ShouldMapTo<TController>(this RouteData routeData, Expression<Action<TController>> action, string httpMethod) where TController : ApiController
         {
             Assert.IsNotNull(routeData, "The URL did not match any route");
 

--- a/test/WebApiContribTests/Testing/RouteTestingExtensionsTests.cs
+++ b/test/WebApiContribTests/Testing/RouteTestingExtensionsTests.cs
@@ -50,18 +50,10 @@ namespace WebApiContribTests.Testing
             {
                 return new List<int>();
             }
-        }
 
-        public class RestfulController : ApiController
-        {
-            public List<int> Get()
+            public bool Post(string foobar)
             {
-                return new List<int>();
-            }
-
-            public List<int> Get(int id)
-            {
-                return new List<int>();
+                return true;
             }
         }
 
@@ -204,6 +196,13 @@ namespace WebApiContribTests.Testing
         {
             const string url = "~/api/sample/filter";
             url.ShouldMapTo<SampleController>(x => x.Filter(default(int)));
+        }
+
+        [Test]
+        public void ShouldMapTo_IgnoresReturnTypeOfAction()
+        {
+            const string url = "~/api/foobar";
+            url.ShouldMapTo<FoobarController>(x => x.Post(null), "POST");
         }
     }
 }


### PR DESCRIPTION
Fixes the bug where the extension method RouteTestingExtensions.ShouldMapTo throws an InvalidCastException when testing routes for a controller action that returns a value type (e.g. int or bool).
