### PR TITLE
Changed BasicAuthenticationHandler to use indexOf method instead a split...

### DIFF
--- a/src/WebApiContrib/MessageHandlers/BasicAuthenticationHandler.cs
+++ b/src/WebApiContrib/MessageHandlers/BasicAuthenticationHandler.cs
@@ -40,12 +40,13 @@ namespace WebApiContrib.MessageHandlers
         {
             try
             {
-                var credentials = Encoding.ASCII.GetString(Convert.FromBase64String(authHeader.ToString().Substring(6))).Split(':');
+                var credentials = Encoding.ASCII.GetString(Convert.FromBase64String(authHeader.ToString().Substring(6)));
+                int splitOn = credentials.IndexOf(':');
 
                 return new BasicCredentials
                 {
-                    Username = credentials[0],
-                    Password = credentials[1]
+                    Username = credentials.Substring(0, splitOn),
+                    Password = credentials.Substring(splitOn + 1)
                 };
             }
             catch { }


### PR DESCRIPTION
... since passwords could contain colons.

According to the RFC (http://www.ietf.org/rfc/rfc2617.txt), it is valid
for the password to contain a colon ':' character.
