### PR TITLE
Added encoding parameter to PlainTextFormatter

### DIFF
--- a/src/WebApiContrib/Formatting/PlainTextFormatter.cs
+++ b/src/WebApiContrib/Formatting/PlainTextFormatter.cs
@@ -4,14 +4,19 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Threading.Tasks;
+
 
 namespace WebApiContrib.Formatting
 {
     public class PlainTextFormatter : MediaTypeFormatter
     {
-        public PlainTextFormatter()
+        private readonly Encoding _encoding;
+
+        public PlainTextFormatter(Encoding encoding = null)
         {
+            this._encoding = encoding ?? Encoding.Default;
             SupportedMediaTypes.Add(new MediaTypeHeaderValue("text/plain"));
         }
 
@@ -27,7 +32,7 @@ namespace WebApiContrib.Formatting
 
     	public override Task<object> ReadFromStreamAsync(Type type, Stream stream, HttpContent content, IFormatterLogger formatterLogger)
         {
-            var reader = new StreamReader(stream);
+            var reader = new StreamReader(stream, _encoding);
             string value = reader.ReadToEnd();
 
             var tcs = new TaskCompletionSource<object>();
@@ -37,7 +42,7 @@ namespace WebApiContrib.Formatting
 
     	public override Task WriteToStreamAsync(Type type, object value, Stream stream, HttpContent content, TransportContext transportContext)
         {
-            var writer = new StreamWriter(stream);
+            var writer = new StreamWriter(stream, _encoding);
             writer.Write((string) value);
             writer.Flush();
             

--- a/test/WebApiContribTests/Formatting/PlainTextFormatterTests.cs
+++ b/test/WebApiContribTests/Formatting/PlainTextFormatterTests.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net.Http;
+using System.Text;
 using NUnit.Framework;
 using Should;
 using WebApiContrib.Formatting;
@@ -49,6 +50,53 @@ namespace WebApiContribTests.Formatting
             
             var memoryStream = new MemoryStream();
             var sr = new StreamWriter(memoryStream);
+            sr.Write(value);
+            sr.Flush();
+            memoryStream.Position = 0;
+            var content = new StringContent(string.Empty);
+            content.Headers.Clear();
+
+            var resultTask = formatter.ReadFromStreamAsync(typeof(string), memoryStream, content, null);
+
+            resultTask.Wait();
+
+            resultTask.Result.ShouldBeType<String>();
+
+            var result = (String)resultTask.Result;
+
+            result.ShouldEqual(value);
+        }
+
+        [Test]
+        public void Should_write_UTF8_string_to_stream()
+        {
+            var formatter = new PlainTextFormatter(Encoding.UTF8);
+
+
+            var content = new StringContent(string.Empty);
+            content.Headers.Clear();
+            var memoryStream = new MemoryStream();
+            var value = "Bonjour tout le monde français";
+            var resultTask = formatter.WriteToStreamAsync(typeof(string), value, memoryStream, content, transportContext: null);
+
+            resultTask.Wait();
+
+            memoryStream.Position = 0;
+            string serializedString = new StreamReader(memoryStream, Encoding.UTF8).ReadToEnd();
+
+
+            serializedString.ShouldEqual(value);
+        }
+
+
+        [Test]
+        public void Should_read_serialized_UTF8_object_from_stream()
+        {
+            var formatter = new PlainTextFormatter(Encoding.UTF8);
+            var value = "Bonjour tout le monde Français";
+
+            var memoryStream = new MemoryStream();
+            var sr = new StreamWriter(memoryStream, Encoding.UTF8);
             sr.Write(value);
             sr.Flush();
             memoryStream.Position = 0;


### PR DESCRIPTION
PlainTextFormatter doesn't support Unicode so I have added the ability to specify a encoding when one is created.
