### PR TITLE
Removing CommonServiceLocator from packages.config

### DIFF
--- a/src/WebApiContrib.Testing/packages.config
+++ b/src/WebApiContrib.Testing/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.0" />
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />


### PR DESCRIPTION
Remove unnecessary reference, makes NuGet manager download a package for
nothing.
