### PR TITLE
HeadMessageHandler: Support empty content eg. 302

### DIFF
--- a/src/WebApiContrib/MessageHandlers/HeadMessageHandler.cs
+++ b/src/WebApiContrib/MessageHandlers/HeadMessageHandler.cs
@@ -22,7 +22,8 @@ namespace WebApiContrib.MessageHandlers {
                     .ContinueWith<HttpResponseMessage>(task => {
                         var response = task.Result;
                         response.RequestMessage.Method = HttpMethod.Head;
-                        response.Content = new HeadContent(response.Content);
+                        if (response.Content != null)
+                            response.Content = new HeadContent(response.Content);
                         return task.Result;
                     });
 

--- a/test/WebApiContribTests/MessageHandlers/HeadMessageHandlerTests.cs
+++ b/test/WebApiContribTests/MessageHandlers/HeadMessageHandlerTests.cs
@@ -25,7 +25,7 @@ namespace WebApiContribTests.MessageHandlers
 
             var response = client.SendAsync(requestMessage).Result;
 
-            Assert.AreEqual("Boo",response.ReasonPhrase);
+            Assert.AreEqual("Boo", response.ReasonPhrase);
             Assert.AreEqual(0, response.Content.Headers.ContentLength);
         }
 
@@ -47,6 +47,28 @@ namespace WebApiContribTests.MessageHandlers
 
             Assert.AreEqual("Boo", response.ReasonPhrase);
             Assert.AreEqual("Hello world", response.Content.ReadAsStringAsync().Result);
+        }
+
+        [Test]
+        public void Should_support_empry_bodies()
+        {
+            var messageHandler302 = new HeadMessageHandler();
+            var reasonPhrase = "302 from Controller.Redirect(url)";
+            messageHandler302.InnerHandler = new PrecannedMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                ReasonPhrase = reasonPhrase,
+                Content = null
+            });
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Head, "http://foo/bar");
+
+            var client = new HttpClient(messageHandler302);
+
+            var response = client.SendAsync(requestMessage).Result;
+
+            Assert.AreEqual(reasonPhrase, response.ReasonPhrase);
+            Assert.AreEqual(null, response.Content);
+
         }
     }
 }


### PR DESCRIPTION
This fixes the problem that if you make a response with no content eg. a redirect, HeadContent will be called with a null value and throw a NullReferenceException.
